### PR TITLE
Use dotenv to load env variables from .env files

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 SEG_PROJECT_FOLDER=~/git/pieces
 SEG_CARABINER_BIN=~/Downloads/Carabiner_Linux_x64
+SEG_TIDAL_BOOT_PATH=/home/tidal/boot.tidal

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+SEG_PROJECT_FOLDER=~/git/pieces
+SEG_CARABINER_BIN=~/Downloads/Carabiner_Linux_x64

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Stretch goals
 
 After cloning the repo, install all dependencies by runnin `yarn install`.
 
+Then, copy the file `.env.sample` as `.env` and adjust them accordingly:
+
+* `SEG_PROJECT_FOLDER`: Path to your session files
+* `SEG_CARABINER_BIN`: Path to Carabiner binary
+* `SEG_TIDAL_BOOT_PATH`: Path to TidalCycles bootloading script
+
 To run the project (as of today), you must start the `webapp` as well as the `backend`. Run the following commands
 
 - `yarn start`: will start the webapp on port localhost:3000

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "gen": "yarn run peggy -o src/lang/tidal/parser.js src/lang/tidal/parser.peggy",
-    "backend": "SEG_PROJECT_FOLDER=~/git/pieces SEG_CARABINER_BIN=~/Downloads/Carabiner_Linux_x64 node src/web/backend.js",
+    "backend": "node src/web/backend.js",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@uiw/react-codemirror": "^4.7.0",
     "axios": "^0.27.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.0.1",
     "jest": "^28.0.3",
     "klaw-sync": "^6.0.0",
     "peggy": "^1.2.0",

--- a/src/web/backend.js
+++ b/src/web/backend.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const express = require("express");
 const app = express();
 const bodyParser = require("body-parser");

--- a/src/web/backend.js
+++ b/src/web/backend.js
@@ -13,7 +13,7 @@ const projFolder = process.env?.SEG_PROJECT_FOLDER || "~/.seg/projects";
 
 // Configuration for tidal. Generalize this in the future
 const command = "ghci";
-const params = ["-ghci-script", "/home/tidal/boot.tidal"];
+const params = ["-ghci-script", process.env?.SEG_TIDAL_BOOT_PATH || "/home/tidal/boot.tidal"];
 
 // Server setup
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,6 +4077,11 @@ dotenv@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"


### PR DESCRIPTION
CRA already does this, so I thought it'd be nice to use it on the backend as well. This also removes the hardcoded paths on the `backend` package script. There is a `.env.sample` file to copy from, when installing for the first time.